### PR TITLE
Fix Crypto stock returns

### DIFF
--- a/yahoo_finance_async/api.py
+++ b/yahoo_finance_async/api.py
@@ -155,6 +155,9 @@ class OHLC:
 
             return candles, meta
 
+        except TypeError as e:
+            return candles, meta
+
         except Exception as e:
             raise APIError(
                 f"Unable to parse the OHLC candle data from the Yahoo Finance API response - {e}"


### PR DESCRIPTION
API returns from Yahoo on CryptoCurrencies (BTC-USD, DOGE-USD, etc)
are empty in their last list element. This caused parse_ohlc to
error when attempting to float a NoneType.

By catching these TypeErrors, we can still return the last candle
data and metadata in the event that todays OHLC data is None.